### PR TITLE
Ajout d'une clef d'authentification humble bundle

### DIFF
--- a/discordbot/humblebundle.py
+++ b/discordbot/humblebundle.py
@@ -10,10 +10,12 @@ from discord import Client
 
 
 def _isEnable():
-	return ConfigurationHelper().getValue('humble_bundle_enable') and ConfigurationHelper().getIntValue('humble_bundle_channel') != 0
+	helper = ConfigurationHelper()
+	return helper.getValue('humble_bundle_enable') and helper.getIntValue('humble_bundle_channel') != 0 and helper.getValue('humble_bundle_api_key')
 
 def _callHexas():
-	response = requests.get("http://hexas.shionn.org/humble-bundle/json", headers={ "Content-Type": "application/json" })
+	headers = { "Content-Type": "application/json", "api-key":ConfigurationHelper().getValue('humble_bundle_api_key') }
+	response = requests.get("http://hexas.shionn.org/humble-bundle/json", headers=headers)
 	if response.status_code == 200:
 		return response.json()
 	logging.error(f"Échec de la connexion à l'API Humble Bundle. Code de statut HTTP : {response.status_code}")

--- a/webapp/templates/configurations.html
+++ b/webapp/templates/configurations.html
@@ -46,6 +46,8 @@
 			{{channel.name}}</option>
 		{% endfor %}
 	</select>
+	<label for="humble_bundle_api_key">Client id</label>
+	<input name="humble_bundle_api_key" type="text" value="{{ configuration.getValue('humble_bundle_api_key') }}" />
 	<input type="Submit" value="Définir">
 </form>
 {% endblock %}


### PR DESCRIPTION
Ajout d'une clef d'authentification à humble-bundle. 
Il n'est pas possible de tester le rejet car pour l'instant le service humble-bundle ne bloque pas l’accès.