### PR TITLE
Améliore le healthcheck Docker pour détecter les erreurs en temps réel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 **/.venv
 __pycache__
 instance
+logs
 .tio.tokens.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /app
 ENV DEBIAN_FRONTEND=noninteractive
 ENV LANG=fr_FR.UTF-8
 ENV LC_ALL=fr_FR.UTF-8
+ENV PYTHONUNBUFFERED=1
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-utils \
@@ -34,7 +35,7 @@ RUN python3 -m venv /app/venv && \
     chmod +x /start.sh && \
     mkdir -p /app/logs
 
-HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+HEALTHCHECK --interval=1s --timeout=10s --start-period=5s --retries=3 \
   CMD pgrep python > /dev/null && ! (tail -n 1000 $(ls -t /app/logs/*.log 2>/dev/null | head -1) 2>/dev/null | grep -iE "(ERROR|CRITICAL|Exception|sqlite3\.OperationalError)")
 
 CMD ["/start.sh"]

--- a/protondb/__init__.py
+++ b/protondb/__init__.py
@@ -8,24 +8,38 @@ from database.helpers import ConfigurationHelper
 from database.models import GameAlias
 from sqlalchemy import desc,func
 
-def _call_algoliasearch(search_name:str): 
-	config = SearchConfig(ConfigurationHelper().getValue('proton_db_api_id'), 
-						ConfigurationHelper().getValue('proton_db_api_key'))
-	config.set_default_hosts()
-	client = SearchClientSync(config=config)
-	return client.search_single_index(index_name="steamdb",
-											search_params={
-												"query":search_name,
-												"facetFilters":[["appType:Game"]],
-												"hitsPerPage":50},
-											request_options= {'headers':{'Referer':'https://www.protondb.com/'}})
+def _call_algoliasearch(search_name:str):
+	try:
+		config = SearchConfig(ConfigurationHelper().getValue('proton_db_api_id'),
+							ConfigurationHelper().getValue('proton_db_api_key'))
+		config.set_default_hosts()
+		client = SearchClientSync(config=config)
+		return client.search_single_index(index_name="steamdb",
+												search_params={
+													"query":search_name,
+													"facetFilters":[["appType:Game"]],
+													"hitsPerPage":50},
+												request_options= {
+													'headers':{'Referer':'https://www.protondb.com/'},
+													'timeout': 30
+												})
+	except Exception as e:
+		logging.error(f'Erreur lors de la recherche Algolia pour "{search_name}" : {e}')
+		return None
 
 def _call_summary(id): 
-	response = requests.get(f'http://jazzy-starlight-aeea19.netlify.app/api/v1/reports/summaries/{id}.json')
-	if (response.status_code == 200) :
-		return response.json()
-	logging.error(f'Échec de la récupération des données ProtonDB pour le jeu {id}. Code de statut HTTP : {response.status_code}')
-	return None
+	try:
+		response = requests.get(f'http://jazzy-starlight-aeea19.netlify.app/api/v1/reports/summaries/{id}.json', timeout=30)
+		if (response.status_code == 200) :
+			return response.json()
+		logging.error(f'Échec de la récupération des données ProtonDB pour le jeu {id}. Code de statut HTTP : {response.status_code}')
+		return None
+	except (requests.exceptions.SSLError, requests.exceptions.Timeout, requests.exceptions.ConnectionError) as e:
+		logging.error(f'Erreur de connexion ProtonDB pour le jeu {id} : {e}')
+		return None
+	except Exception as e:
+		logging.error(f'Erreur inattendue lors de la récupération ProtonDB pour le jeu {id} : {e}')
+		return None
 
 def _is_name_match(name:str, search_name:str) -> bool:
 	normalized_game_name = re.sub("[^a-z0-9]", "", name.lower())
@@ -37,10 +51,12 @@ def _apply_game_aliases(search_name:str) -> str:
 		search_name = re.sub(re.escape(alias.alias), alias.name, search_name, flags=re.IGNORECASE)
 	return search_name
 
-def searhProtonDb(search_name:str): 
+def searhProtonDb(search_name:str):
 	results = []
 	search_name = _apply_game_aliases(search_name)
 	responses = _call_algoliasearch(search_name)
+	if responses is None:
+		return results
 	for hit in responses.model_dump().get('hits'): 
 		id = hit.get('object_id')
 		name:str = hit.get('name')

--- a/twitchbot/__init__.py
+++ b/twitchbot/__init__.py
@@ -37,14 +37,16 @@ class TwitchBot() :
 			if _isConfigured() : 
 				try : 
 					helper = ConfigurationHelper()
-					self.twitch = await Twitch(helper.getValue('twitch_client_id'), helper.getValue('twitch_client_secret'))
-					await self.twitch.set_user_authentication(helper.getValue('twitch_access_token'), USER_SCOPE, helper.getValue('twitch_refresh_token'))
-					self.chat = await Chat(self.twitch)
+					self.twitch = await asyncio.wait_for(Twitch(helper.getValue('twitch_client_id'), helper.getValue('twitch_client_secret')), timeout=30.0)
+					await asyncio.wait_for(self.twitch.set_user_authentication(helper.getValue('twitch_access_token'), USER_SCOPE, helper.getValue('twitch_refresh_token')), timeout=30.0)
+					self.chat = await asyncio.wait_for(Chat(self.twitch), timeout=30.0)
 					self.chat.register_event(ChatEvent.READY, _onReady)
 					self.chat.register_event(ChatEvent.MESSAGE, _onMessage)
 					# chat.register_event(ChatEvent.SUB, on_sub)
 					self.chat.register_command('hello', _helloCommand)
 					self.chat.start()
+				except asyncio.TimeoutError:
+					logging.error('Timeout lors de la connexion à Twitch. Vérifiez votre connexion réseau.')
 				except Exception as e: 
 					logging.error(f'Échec de l\'authentification Twitch. Vérifiez vos identifiants et redémarrez après correction : {e}')
 			else: 

--- a/webapp/twitch_auth.py
+++ b/webapp/twitch_auth.py
@@ -17,34 +17,53 @@ auth: UserAuthenticator
 def twitchConfigurationHelp():
 	return render_template("twitch-aide.html", token_redirect_url = _buildUrl())
 
-@webapp.route("/configurations/twitch/request-token") 
-async def twitchRequestToken(): 
+@webapp.route("/configurations/twitch/request-token")
+async def twitchRequestToken():
 	global auth
-	helper = ConfigurationHelper()
-	twitch = await Twitch(helper.getValue('twitch_client_id'), helper.getValue('twitch_client_secret'))
-	auth = UserAuthenticator(twitch, USER_SCOPE, url=_buildUrl())
-	return redirect(auth.return_auth_url())
+	try:
+		helper = ConfigurationHelper()
+		import asyncio
+		twitch = await asyncio.wait_for(
+			Twitch(helper.getValue('twitch_client_id'), helper.getValue('twitch_client_secret')),
+			timeout=30.0
+		)
+		auth = UserAuthenticator(twitch, USER_SCOPE, url=_buildUrl())
+		return redirect(auth.return_auth_url())
+	except asyncio.TimeoutError:
+		logging.error('Timeout lors de la connexion à Twitch API pour la demande de token')
+		return redirect(url_for('openConfigurations'))
+	except TwitchAPIException as e:
+		logging.error(f'Erreur API Twitch lors de la demande de token : {e}')
+		return redirect(url_for('openConfigurations'))
+	except Exception as e:
+		logging.error(f'Erreur inattendue lors de la demande de token Twitch : {e}')
+		return redirect(url_for('openConfigurations'))
 
-@webapp.route("/configurations/twitch/receive-token") 
+@webapp.route("/configurations/twitch/receive-token")
 async def twitchReceiveToken():
 	global auth
 	state = request.args.get('state')
 	code = request.args.get('code')
 	if state != auth.state :
-		logging('bad returned state')
+		logging.error('bad returned state')
 		return redirect(url_for('openConfigurations'))
 	if code == None :
-		logging('no returned state')
+		logging.error('no returned code')
 		return redirect(url_for('openConfigurations'))
-		
+
 	try:
-		token, refresh = await auth.authenticate(user_token=code)
+		import asyncio
+		token, refresh = await asyncio.wait_for(auth.authenticate(user_token=code), timeout=30.0)
 		helper = ConfigurationHelper()
 		helper.createOrUpdate('twitch_access_token', token)
 		helper.createOrUpdate('twitch_refresh_token', refresh)
 		db.session.commit()
+	except asyncio.TimeoutError:
+		logging.error('Timeout lors de l\'authentification Twitch')
 	except TwitchAPIException as e:
-		logging(e)
+		logging.error(f'Erreur API Twitch lors de l\'authentification : {e}')
+	except Exception as e:
+		logging.error(f'Erreur inattendue lors de l\'authentification Twitch : {e}')
 	return redirect(url_for('openConfigurations'))
 
 # hack pas fou mais on estime qu'on sera toujours en ssl en connecté


### PR DESCRIPTION
Docker redémarrera le conteneur jusqu'à 3 fois en cas d'erreur avec un délai. Si les 3 tentatives échouent, le conteneur reste arrêté. Les outils de monitoring (Uptime Kuma, Zabbix) peuvent détecter cet incident via l'état du conteneur ou les healthchecks.

Exemple :

<img width="2170" height="73" alt="image" src="https://github.com/user-attachments/assets/2cd10869-5bf5-4e96-b06e-ae18f5922fb7" />

Réponse :

<img width="1341" height="68" alt="image" src="https://github.com/user-attachments/assets/a22103e3-5ba4-4c86-bf91-e1a5dd1f200f" />
